### PR TITLE
Cluster Specific Public Route Table

### DIFF
--- a/modules/vpc/io.tf
+++ b/modules/vpc/io.tf
@@ -20,8 +20,8 @@ variable "subnets" { type = "map" }
 variable "region" {}
 
 
-output "main_route_table_id" { value = "${aws_vpc.main.main_route_table_id}" }
 output "private_route_table_id" { value = "${aws_route_table.private.id}" }
 output "private_subnet_ids" { value = ["${aws_subnet.private.*.id}"] }
+output "public_route_table_id" { value = "${aws_route_table.public.id}" }
 output "public_subnet_ids" { value = ["${aws_subnet.public.*.id}"] }
 output "vpc_id" { value = "${aws_vpc.main.id}" }

--- a/modules/vpc/public_subnets.tf
+++ b/modules/vpc/public_subnets.tf
@@ -27,15 +27,21 @@ resource "aws_internet_gateway" "gateway" {
   }
 }
 
-resource "aws_route" "public" {
-  destination_cidr_block = "0.0.0.0/0"
-  gateway_id = "${aws_internet_gateway.gateway.id}"
-  route_table_id = "${aws_vpc.main.main_route_table_id}"
+resource "aws_route_table" "public" {
+  vpc_id = "${aws_vpc.main.id}"
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = "${aws_internet_gateway.gateway.id}"
+  }
+  tags {
+    KubernetesCluster = "${var.cluster_name}"
+    Name = "${var.cluster_name}-public"
+  }
 }
 
 resource "aws_route_table_association" "public" {
   count = "${length(var.subnets["public_cidr_blocks"])}"
-  route_table_id = "${aws_vpc.main.main_route_table_id}"
+  route_table_id = "${aws_route_table.public.id}"
   subnet_id = "${element(aws_subnet.public.*.id, count.index)}"
 }
 


### PR DESCRIPTION
In CloudFormation I've run into the limitation of being unable to access the VPC main route table (knowingly not a TF limitation) but thought I'd see if you were interested in this AWS recommendation.

### [Custom Route Tables](https://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Route_Tables.html#RouteTables)

Your VPC can have route tables other than the default table. **One way to protect your VPC is to leave the main route table in its original default state (with only the local route), and explicitly associate each new subnet you create with one of the custom route tables you've created. This ensures that you explicitly control how each subnet routes outbound traffic.**

🥂 