### PR TITLE
AZ Specific NAT Gateways

### DIFF
--- a/modules/vpc/private_subnets.tf
+++ b/modules/vpc/private_subnets.tf
@@ -19,32 +19,37 @@ data "template_file" "private_az" {
   template = "${format("%s%s", var.region, element(var.subnets["availability_zones"], count.index))}"
 }
 
-resource "aws_eip" "nat" { vpc = true }
+resource "aws_eip" "nat" {
+   count = "${length(var.subnets["availability_zones"])}"
+   vpc = true
+}
 
 resource "aws_nat_gateway" "nat" {
+  count = "${length(var.subnets["availability_zones"])}"
   depends_on = [
     "aws_eip.nat",
     "aws_internet_gateway.gateway"
   ]
-  allocation_id = "${aws_eip.nat.id}"
-  subnet_id = "${aws_subnet.public.0.id}"
+  allocation_id = "${element(aws_eip.nat.*.id, count.index)}"
+  subnet_id = "${element(aws_subnet.public.*.id, count.index)}"
 }
 
 resource "aws_route_table" "private" {
+  count = "${length(var.subnets["availability_zones"])}"
   vpc_id = "${aws_vpc.main.id}"
   route {
     cidr_block = "0.0.0.0/0"
-    nat_gateway_id = "${aws_nat_gateway.nat.id}"
+    nat_gateway_id = "${element(aws_nat_gateway.nat.*.id, count.index)}"
   }
   tags {
     KubernetesCluster = "${var.cluster_name}"
-    Name = "${var.cluster_name}-private"
+    Name = "${format("%s-private-%s", var.cluster_name, element(var.subnets["availability_zones"], count.index))}"
   }
 }
 
 resource "aws_route_table_association" "private" {
   count = "${length(var.subnets["private_cidr_blocks"])}"
-  route_table_id = "${aws_route_table.private.id}"
+  route_table_id = "${element(aws_route_table.private.*.id, count.index)}"
   subnet_id = "${element(aws_subnet.private.*.id, count.index)}"
 }
 


### PR DESCRIPTION
Add a Private Subnet/Nat GW per AZ for HA.

* [Comparison of NAT Instances and NAT Gateways](https://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/vpc-nat-comparison.html)
>Highly available. NAT gateways in each Availability Zone are implemented with redundancy. Create a NAT gateway in each Availability Zone to ensure zone-independent architecture.
